### PR TITLE
Revise charter's scope of work

### DIFF
--- a/charter.md
+++ b/charter.md
@@ -6,29 +6,14 @@ The mission of the W3C Documentation Community Group (W3C Docs CG) is to ensure 
 
 ## Scope of work
 
-This community group will:
+This community group will support the planning, writing, and maintenance of documentation for web platform technologies by:
 
-- Plan and write new documentation for web platform technologies.
-  - Make sure reference documentation (“the book of web platform features”) is complete.
-  - Identify needs for guides, how-tos, and tutorials, and create them.
-- Work with specification authors to define best practices for web developer documentation, code examples, and information architecture.
-- Maintain and keep documentation up-to-date using modern approaches like docs-as-code
-- Develop tools to create feedback loops between standards and web developer documentation.
-- Coordinate documentation efforts: Collaborate with other W3C community groups, such as [WebDX](https://www.w3.org/community/webdx/), [Security](https://www.w3.org/mission/security/), [Privacy](https://www.w3.org/mission/privacy/), [Accessibility](https://www.w3.org/mission/accessibility/), [Internationalization](https://www.w3.org/mission/internationalization/), [Sustainability](https://www.w3.org/community/sustyweb/) and integrate their findings and best practices into documentation.
-- Be a resource for resources: map documentation sources for web developers.
-  - Identify reliable sources of information.
-  - Invite them to be part of the conversations in this community group.
-- Drive adoption (or deprecation) of web platform technologies:
-  - Identify web platform features where sparse docs prevent adoption and understanding.
-  - Interpret developer surveys (such as the [MDN short survey on web developer’s experience with Web Security](https://github.com/web-platform-dx/developer-research/blob/main/mdn-short-surveys/2023-05-15-security-dx/interpretation.md) and understand the role of documentation in identified shortcomings.
-- Ensure documentation relevance: coordinate horizontal efforts to get outdated docs updated such as by helping reach out to the right docs owners.
-- Be a hub for web documentation: when docs-related efforts, changes, and/or projects appear, coordinate with the relevant stakeholders to get these amplified.
-
-## Key deliverables
-
-- Write and maintain docs in [mdn/content](https://github.com/mdn/content). See the [backlog](https://openwebdocs.github.io/web-docs-backlog/) for missing reference pages.
-- Identify best practices for web developer documentation.
-- Drive adoption and understanding of web technologies.
+- Introducing and coordinating authors, editors, subject-matter experts, and other participants to the documentation process
+- Identifying needs for guides, how-tos, tutorials, and references
+- Creating feedback loops between standards and web developer documentation
+- Collaborating with other W3C community groups, such as [WebDX](https://www.w3.org/community/webdx/), [Security](https://www.w3.org/mission/security/), [Privacy](https://www.w3.org/mission/privacy/), [Accessibility](https://www.w3.org/mission/accessibility/), [Internationalization](https://www.w3.org/mission/internationalization/), [Sustainability](https://www.w3.org/community/sustyweb/)
+- Evaluating documentation efforts
+- Promoting published documentation and documentation-related research
 
 ## Out of scope
 


### PR DESCRIPTION
At the first Docs CG meeting, I suggested that initial draft of the charter did not capture the spirit of the work under discussion or the relationship of the CG to other organizations and efforts. I'm proposing a slimmed-down version of the CG's scope of work, to focus on coordination, relationship building, and information sharing, rather than on docs writing and maintenance per se.

I've also dropped the key deliverables sections, since I think it's slightly premature to formalize what those deliverables might be, in light of the revised scope of work.